### PR TITLE
Add cleanup routine for sensitive buffers

### DIFF
--- a/jsean.c
+++ b/jsean.c
@@ -4,6 +4,7 @@
 #include <time.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
+#include <openssl/crypto.h>
 
 #define MAX_FIELDS 10
 #define MAX_VERSIONS 20
@@ -119,6 +120,16 @@ int decrypt_field(const unsigned char *ciphertext, int ciphertext_len, const uns
 
     EVP_CIPHER_CTX_free(ctx);
     return plaintext_len;
+}
+
+// Overwrite sensitive buffers before program exit
+void cleanup_jsean(JSean *jsean) {
+    OPENSSL_cleanse(jsean->aes_key, AES_KEY_SIZE);
+    OPENSSL_cleanse(jsean->aes_iv, AES_IV_SIZE);
+
+    for (int i = 0; i < jsean->data_count; i++) {
+        OPENSSL_cleanse(jsean->data[i].value, sizeof(jsean->data[i].value));
+    }
 }
 
 // Check if user has permission to access or modify a field
@@ -243,5 +254,6 @@ int main() {
     retrieve_data_field(&jsean, "confidential_info", output, "editor");  // Should fail
     store_data_field(&jsean, "confidential_info", "NewSensitiveData", "technician", "editor");  // Should fail
 
+    cleanup_jsean(&jsean);
     return 0;
 }


### PR DESCRIPTION
## Summary
- include `<openssl/crypto.h>` to use `OPENSSL_cleanse`
- add `cleanup_jsean` to overwrite AES key, IV and field buffers
- call the cleanup routine before exiting `main`

## Testing
- `gcc -o jsean jsean.c -lcrypto`
- `./jsean`

------
https://chatgpt.com/codex/tasks/task_e_684099b6f8048328a1bbb6327099770b