### PR TITLE
Add per-field IV and ciphertext handling

### DIFF
--- a/jsean.c
+++ b/jsean.c
@@ -34,7 +34,10 @@ typedef struct {
 // A single data field
 typedef struct {
     char key[50];
-    char value[100];
+    unsigned char value[128];  // Can hold binary ciphertext
+    int value_len;             // Length of data stored in value
+    unsigned char iv[AES_IV_SIZE];
+    unsigned char tag[AES_TAG_SIZE];
     int is_encrypted;
 } DataField;
 
@@ -83,12 +86,16 @@ void initialize(JSean *jsean, SchemaField *schema, int schema_count) {
 }
 
 // AES-GCM encryption function for field values
-int encrypt_field(const unsigned char *plaintext, int plaintext_len, unsigned char *ciphertext, unsigned char *tag, JSean *jsean) {
+int encrypt_field(const unsigned char *plaintext, int plaintext_len,
+                  unsigned char *ciphertext, unsigned char *tag,
+                  JSean *jsean, const unsigned char *iv) {
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
     int len, ciphertext_len;
 
-    EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, jsean->aes_key, jsean->aes_iv);
-    EVP_EncryptUpdate(ctx, NULL, &len, NULL, plaintext_len); // Set the length of the AAD
+    EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL);
+    EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, AES_IV_SIZE, NULL);
+    EVP_EncryptInit_ex(ctx, NULL, NULL, jsean->aes_key, iv);
+
     EVP_EncryptUpdate(ctx, ciphertext, &len, plaintext, plaintext_len);
     ciphertext_len = len;
 
@@ -101,12 +108,16 @@ int encrypt_field(const unsigned char *plaintext, int plaintext_len, unsigned ch
 }
 
 // AES-GCM decryption function for field values
-int decrypt_field(const unsigned char *ciphertext, int ciphertext_len, const unsigned char *tag, unsigned char *plaintext, JSean *jsean) {
+int decrypt_field(const unsigned char *ciphertext, int ciphertext_len,
+                  const unsigned char *tag, unsigned char *plaintext,
+                  JSean *jsean, const unsigned char *iv) {
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
     int len, plaintext_len;
 
-    EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, jsean->aes_key, jsean->aes_iv);
-    EVP_DecryptUpdate(ctx, NULL, &len, NULL, ciphertext_len); // Set the length of the AAD
+    EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL);
+    EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, AES_IV_SIZE, NULL);
+    EVP_DecryptInit_ex(ctx, NULL, NULL, jsean->aes_key, iv);
+
     EVP_DecryptUpdate(ctx, plaintext, &len, ciphertext, ciphertext_len);
     plaintext_len = len;
 
@@ -154,18 +165,23 @@ void store_data_field(JSean *jsean, const char *key, const char *value, const ch
 
     int is_encrypted = schema_field->is_encrypted;
     unsigned char encrypted_value[128];
-    unsigned char tag[AES_TAG_SIZE];
     int encrypted_len = 0;
 
     DataField *data_field = &jsean->data[jsean->data_count++];
     strcpy(data_field->key, key);
     if (is_encrypted) {
-        encrypted_len = encrypt_field((unsigned char *)value, strlen(value), encrypted_value, tag, jsean);
-        snprintf(data_field->value, sizeof(data_field->value), "%.*s", encrypted_len, encrypted_value);
+        RAND_bytes(data_field->iv, AES_IV_SIZE);
+        encrypted_len = encrypt_field((unsigned char *)value, strlen(value),
+                                      encrypted_value, data_field->tag,
+                                      jsean, data_field->iv);
+        memcpy(data_field->value, encrypted_value, encrypted_len);
+        data_field->value_len = encrypted_len;
         data_field->is_encrypted = 1;
         printf("Stored encrypted value for key '%s'\n", key);
     } else {
-        strcpy(data_field->value, value);
+        strncpy((char *)data_field->value, value, sizeof(data_field->value) - 1);
+        data_field->value_len = strlen(value);
+        data_field->value[data_field->value_len] = '\0';
         data_field->is_encrypted = 0;
         printf("Stored plain value for key '%s'\n", key);
     }
@@ -195,9 +211,13 @@ void retrieve_data_field(JSean *jsean, const char *key, char *output, const char
     for (int i = 0; i < jsean->data_count; i++) {
         if (strcmp(jsean->data[i].key, key) == 0) {
             if (jsean->data[i].is_encrypted) {
-                unsigned char decrypted_value[100];
-                unsigned char tag[AES_TAG_SIZE];
-                int decrypted_len = decrypt_field((unsigned char *)jsean->data[i].value, strlen(jsean->data[i].value), tag, decrypted_value, jsean);
+                unsigned char decrypted_value[128];
+                int decrypted_len = decrypt_field(jsean->data[i].value,
+                                                 jsean->data[i].value_len,
+                                                 jsean->data[i].tag,
+                                                 decrypted_value,
+                                                 jsean,
+                                                 jsean->data[i].iv);
                 if (decrypted_len < 0) {
                     printf("Decryption failed for key '%s'\n", key);
                     return;
@@ -206,7 +226,8 @@ void retrieve_data_field(JSean *jsean, const char *key, char *output, const char
                 strcpy(output, (char *)decrypted_value);
                 printf("Retrieved decrypted value for key '%s'\n", key);
             } else {
-                strcpy(output, jsean->data[i].value);
+                memcpy(output, jsean->data[i].value, jsean->data[i].value_len);
+                output[jsean->data[i].value_len] = '\0';
             }
             return;
         }


### PR DESCRIPTION
## Summary
- extend `DataField` with storage for IV, tag, and binary length
- update `encrypt_field`/`decrypt_field` APIs to receive an IV parameter
- generate a random IV for each encrypted field and store IV, tag, and ciphertext length
- use stored IV and tag when decrypting and handle binary ciphertext properly

## Testing
- `gcc -o jsean jsean.c -lcrypto`
- `./jsean | cat -v`

------
https://chatgpt.com/codex/tasks/task_e_684099b32fa48328a2807646d9777219