### PR TITLE
Check RAND_bytes failures

### DIFF
--- a/jsean.c
+++ b/jsean.c
@@ -81,7 +81,10 @@ void initialize(JSean *jsean, SchemaField *schema, int schema_count) {
     jsean->version_count = 0;
     memcpy(jsean->schema, schema, schema_count * sizeof(SchemaField));
     jsean->schema_count = schema_count;
-    RAND_bytes(jsean->aes_key, AES_KEY_SIZE); // Generate AES key
+    if (RAND_bytes(jsean->aes_key, AES_KEY_SIZE) != 1) { // Generate AES key
+        fprintf(stderr, "RAND_bytes failed in initialize\n");
+        exit(EXIT_FAILURE);
+    }
 }
 
 // AES-GCM encryption function for field values
@@ -91,7 +94,6 @@ int encrypt_field(const unsigned char *plaintext, int plaintext_len, unsigned ch
     int len, ciphertext_len;
 
     EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, jsean->aes_key, iv);
-    EVP_EncryptUpdate(ctx, NULL, &len, NULL, plaintext_len); // Set the length of the AAD
 
     EVP_EncryptUpdate(ctx, ciphertext, &len, plaintext, plaintext_len);
     ciphertext_len = len;
@@ -111,7 +113,6 @@ int decrypt_field(const unsigned char *ciphertext, int ciphertext_len, const uns
     int len, plaintext_len;
 
     EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, jsean->aes_key, iv);
-    EVP_DecryptUpdate(ctx, NULL, &len, NULL, ciphertext_len); // Set the length of the AAD
     EVP_DecryptUpdate(ctx, plaintext, &len, ciphertext, ciphertext_len);
     plaintext_len = len;
 
@@ -129,7 +130,6 @@ int decrypt_field(const unsigned char *ciphertext, int ciphertext_len, const uns
 // Overwrite sensitive buffers before program exit
 void cleanup_jsean(JSean *jsean) {
     OPENSSL_cleanse(jsean->aes_key, AES_KEY_SIZE);
-    OPENSSL_cleanse(jsean->aes_iv, AES_IV_SIZE);
 
     for (int i = 0; i < jsean->data_count; i++) {
         OPENSSL_cleanse(jsean->data[i].value, sizeof(jsean->data[i].value));
@@ -217,7 +217,10 @@ void store_data_field(JSean *jsean, const char *key, const char *value, const ch
     snprintf(data_field->key, sizeof(data_field->key), "%s", key);
     if (is_encrypted) {
 
-        RAND_bytes(data_field->iv, AES_IV_SIZE);
+        if (RAND_bytes(data_field->iv, AES_IV_SIZE) != 1) {
+            fprintf(stderr, "RAND_bytes failed in store_data_field\n");
+            exit(EXIT_FAILURE);
+        }
         encrypted_len = encrypt_field((unsigned char *)value, strlen(value), encrypted_value,
                                       data_field->tag, data_field->iv, jsean);
         memcpy(data_field->value, encrypted_value, encrypted_len);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -11,13 +11,16 @@ void test_encryption() {
     const char *plaintext = "HelloWorld";
     unsigned char ciphertext[128];
     unsigned char tag[AES_TAG_SIZE];
+    unsigned char iv[AES_IV_SIZE];
+    RAND_bytes(iv, AES_IV_SIZE);
     int cipher_len = encrypt_field((const unsigned char *)plaintext,
                                    strlen(plaintext),
                                    ciphertext,
                                    tag,
+                                   iv,
                                    &jsean);
     unsigned char decrypted[128];
-    int plain_len = decrypt_field(ciphertext, cipher_len, tag, decrypted, &jsean);
+    int plain_len = decrypt_field(ciphertext, cipher_len, tag, decrypted, iv, &jsean);
     assert(plain_len >= 0);
     decrypted[plain_len] = '\0';
     assert(strcmp((char *)decrypted, plaintext) == 0);
@@ -39,7 +42,7 @@ void test_permission() {
     assert(jsean.data_count == count_before + 1); // stored
 
     char output[100] = "unchanged";
-    retrieve_data_field(&jsean, "confidential", output, "editor");
+    retrieve_data_field(&jsean, "confidential", output, sizeof(output), "editor");
     assert(strcmp(output, "unchanged") == 0); // permission denied
 
     printf("test_permission passed\n");


### PR DESCRIPTION
## Summary
- validate RAND_bytes usage in initialization and storage
- update encryption and decryption helpers
- align unit tests with new API

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6840c2a895008328974791205e7c2b86