### PR TITLE
Fix cleanup call for undefined aes_iv

### DIFF
--- a/jsean.c
+++ b/jsean.c
@@ -129,7 +129,6 @@ int decrypt_field(const unsigned char *ciphertext, int ciphertext_len, const uns
 // Overwrite sensitive buffers before program exit
 void cleanup_jsean(JSean *jsean) {
     OPENSSL_cleanse(jsean->aes_key, AES_KEY_SIZE);
-    OPENSSL_cleanse(jsean->aes_iv, AES_IV_SIZE);
 
     for (int i = 0; i < jsean->data_count; i++) {
         OPENSSL_cleanse(jsean->data[i].value, sizeof(jsean->data[i].value));


### PR DESCRIPTION
## Summary
- remove call to OPENSSL_cleanse on non-existent `aes_iv` field

## Testing
- `make test` *(fails: incompatible test harness)*

------
https://chatgpt.com/codex/tasks/task_e_6840c2a70a20832896217ac3d00c95f7